### PR TITLE
print stackql version in action logs and update test to validate regi…

### DIFF
--- a/.github/workflows/setup-stackql-test.yml
+++ b/.github/workflows/setup-stackql-test.yml
@@ -35,11 +35,11 @@ jobs:
         echo "Registry list output:"
         echo "$OUTPUT"
 
-        # When the wrapper is active, @actions/exec writes stackql's stdout directly to the
-        # wrapper process's stdout, and core.debug() appends ::debug:: annotations immediately
-        # after (on the same line, since the JSON has no trailing newline). Strip all GitHub
-        # Actions workflow commands (::name::value) before handing the output to jq.
-        CLEAN_JSON=$(echo "$OUTPUT" | sed 's/::[a-z-]*::.*$//' | grep -v '^[[:space:]]*$')
+        # When the wrapper is active, @actions/exec also prints the command line before the
+        # output, and core.debug() appends ::debug:: annotations immediately after the JSON
+        # (on the same line, since the JSON has no trailing newline). Strip workflow commands
+        # and then keep only lines that look like JSON (starting with [ or {).
+        CLEAN_JSON=$(echo "$OUTPUT" | sed 's/::[a-z-]*::.*$//' | grep -E '^\s*[\[{]')
 
         # Validate JSON structure: array of objects each with provider and version keys
         echo "$CLEAN_JSON" | jq -e 'type == "array" and (all(.[]; has("provider") and has("version")))' > /dev/null

--- a/.github/workflows/setup-stackql-test.yml
+++ b/.github/workflows/setup-stackql-test.yml
@@ -29,29 +29,12 @@ jobs:
       with:
         use_wrapper: ${{matrix.use_wrapper}}
 
-    - name: Get Stackql Version
-      id: get-stackql-version
+    - name: Run Registry List and Validate
       run: |
-        echo "stackql_version<<EOF" >> $GITHUB_ENV
-        stackql --version >> $GITHUB_ENV
-        echo "EOF" >> $GITHUB_ENV
+        OUTPUT=$(stackql exec --output json "REGISTRY LIST")
+        echo "Registry list output:"
+        echo "$OUTPUT"
 
-    - name: Validate Stackql Version
-      run: |
-        # Extract only the relevant line containing version information
-        VERSION_OUTPUT=$(echo "${{ env.stackql_version }}" | grep -E 'stackql v[0-9]+\.[0-9]+\.[0-9]+')
-        echo "Version output: $VERSION_OUTPUT"
-
-        SEMVER_REGEX="v[0-9]+\.[0-9]+\.[0-9]+"
-        PLATFORM_REGEX="(Linux|Darwin|Windows|Homebrew)"
-
-        if ! [[ "$VERSION_OUTPUT" =~ $SEMVER_REGEX ]]; then
-          echo "Semantic version does not match expected format"
-          exit 1
-        fi
-        if ! [[ "$VERSION_OUTPUT" =~ $PLATFORM_REGEX ]]; then
-          echo "Platform information does not match expected formats"
-          exit 1
-        fi
-
-        echo "version output validated successfully."
+        # Validate JSON structure: array of objects each with provider and version keys
+        echo "$OUTPUT" | jq -e 'type == "array" and (all(.[]; has("provider") and has("version")))' > /dev/null
+        echo "Registry list validated successfully."

--- a/.github/workflows/setup-stackql-test.yml
+++ b/.github/workflows/setup-stackql-test.yml
@@ -39,19 +39,19 @@ jobs:
     - name: Validate Registry List
       run: |
         echo "Registry list output:"
-        echo "${{ env.registry_list_output }}"
+        echo "$registry_list_output"
 
         # Validate header row: expect | provider | and | version | columns
         # Use [[:space:]] instead of \s for macOS bash 3.2 compatibility
         HEADER_REGEX='\|[[:space:]]*provider[[:space:]]*\|[[:space:]]*version[[:space:]]*\|'
-        if ! [[ "${{ env.registry_list_output }}" =~ $HEADER_REGEX ]]; then
+        if ! [[ "$registry_list_output" =~ $HEADER_REGEX ]]; then
           echo "Registry list header does not match expected format"
           exit 1
         fi
 
         # Validate at least one data row: | <name> | v<major>.<minor>.<patch> |
         DATA_ROW_REGEX='\|[[:space:]]*[a-z][a-z0-9_]*[[:space:]]*\|[[:space:]]*v[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*\|'
-        if ! [[ "${{ env.registry_list_output }}" =~ $DATA_ROW_REGEX ]]; then
+        if ! [[ "$registry_list_output" =~ $DATA_ROW_REGEX ]]; then
           echo "Registry list does not contain a valid data row"
           exit 1
         fi

--- a/.github/workflows/setup-stackql-test.yml
+++ b/.github/workflows/setup-stackql-test.yml
@@ -42,14 +42,15 @@ jobs:
         echo "${{ env.registry_list_output }}"
 
         # Validate header row: expect | provider | and | version | columns
-        HEADER_REGEX='\|\s*provider\s*\|\s*version\s*\|'
+        # Use [[:space:]] instead of \s for macOS bash 3.2 compatibility
+        HEADER_REGEX='\|[[:space:]]*provider[[:space:]]*\|[[:space:]]*version[[:space:]]*\|'
         if ! [[ "${{ env.registry_list_output }}" =~ $HEADER_REGEX ]]; then
           echo "Registry list header does not match expected format"
           exit 1
         fi
 
         # Validate at least one data row: | <name> | v<major>.<minor>.<patch> |
-        DATA_ROW_REGEX='\|\s*[a-z][a-z0-9_]*\s*\|\s*v[0-9]+\.[0-9]+\.[0-9]+\s*\|'
+        DATA_ROW_REGEX='\|[[:space:]]*[a-z][a-z0-9_]*[[:space:]]*\|[[:space:]]*v[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*\|'
         if ! [[ "${{ env.registry_list_output }}" =~ $DATA_ROW_REGEX ]]; then
           echo "Registry list does not contain a valid data row"
           exit 1

--- a/.github/workflows/setup-stackql-test.yml
+++ b/.github/workflows/setup-stackql-test.yml
@@ -35,6 +35,12 @@ jobs:
         echo "Registry list output:"
         echo "$OUTPUT"
 
+        # When the wrapper is active, @actions/exec writes stackql's stdout directly to the
+        # wrapper process's stdout, and core.debug() appends ::debug:: annotations immediately
+        # after (on the same line, since the JSON has no trailing newline). Strip all GitHub
+        # Actions workflow commands (::name::value) before handing the output to jq.
+        CLEAN_JSON=$(echo "$OUTPUT" | sed 's/::[a-z-]*::.*$//' | grep -v '^[[:space:]]*$')
+
         # Validate JSON structure: array of objects each with provider and version keys
-        echo "$OUTPUT" | jq -e 'type == "array" and (all(.[]; has("provider") and has("version")))' > /dev/null
+        echo "$CLEAN_JSON" | jq -e 'type == "array" and (all(.[]; has("provider") and has("version")))' > /dev/null
         echo "Registry list validated successfully."

--- a/.github/workflows/setup-stackql-test.yml
+++ b/.github/workflows/setup-stackql-test.yml
@@ -29,18 +29,30 @@ jobs:
       with:
         use_wrapper: ${{matrix.use_wrapper}}
 
-    - name: Run Registry List and Validate
+    - name: Run Registry List
+      id: run-registry-list
       run: |
-        OUTPUT=$(stackql exec --output json "REGISTRY LIST")
+        echo "registry_list_output<<EOF" >> $GITHUB_ENV
+        stackql exec "REGISTRY LIST" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+
+    - name: Validate Registry List
+      run: |
         echo "Registry list output:"
-        echo "$OUTPUT"
+        echo "${{ env.registry_list_output }}"
 
-        # When the wrapper is active, @actions/exec also prints the command line before the
-        # output, and core.debug() appends ::debug:: annotations immediately after the JSON
-        # (on the same line, since the JSON has no trailing newline). Strip workflow commands
-        # and then keep only lines that look like JSON (starting with [ or {).
-        CLEAN_JSON=$(echo "$OUTPUT" | sed 's/::[a-z-]*::.*$//' | grep -E '^\s*[\[{]')
+        # Validate header row: expect | provider | and | version | columns
+        HEADER_REGEX='\|\s*provider\s*\|\s*version\s*\|'
+        if ! [[ "${{ env.registry_list_output }}" =~ $HEADER_REGEX ]]; then
+          echo "Registry list header does not match expected format"
+          exit 1
+        fi
 
-        # Validate JSON structure: array of objects each with provider and version keys
-        echo "$CLEAN_JSON" | jq -e 'type == "array" and (all(.[]; has("provider") and has("version")))' > /dev/null
+        # Validate at least one data row: | <name> | v<major>.<minor>.<patch> |
+        DATA_ROW_REGEX='\|\s*[a-z][a-z0-9_]*\s*\|\s*v[0-9]+\.[0-9]+\.[0-9]+\s*\|'
+        if ! [[ "${{ env.registry_list_output }}" =~ $DATA_ROW_REGEX ]]; then
+          echo "Registry list does not contain a valid data row"
+          exit 1
+        fi
+
         echo "Registry list validated successfully."

--- a/dist/index.js
+++ b/dist/index.js
@@ -34544,6 +34544,13 @@ async function setup () {
       await makeExecutable(cliPath, osPlatform);
     }
 
+    // Print stackql version to action logs
+    const exeSuffix = osPlatform === 'win32' ? '.exe' : '';
+    const stackqlBin = external_path_namespaceObject.join(cliPath, `stackql${exeSuffix}`);
+    info('stackql version:');
+    const versionOutput = (0,external_child_process_namespaceObject.execSync)(`"${stackqlBin}" --version`, { encoding: 'utf-8' });
+    info(versionOutput.trim());
+
     // Check if wrapper is needed and if it's not Darwin
     const useWrapper = getInput('use_wrapper') === 'true';
     if (useWrapper && osPlatform !== 'darwin') {

--- a/index.js
+++ b/index.js
@@ -118,6 +118,13 @@ async function setup () {
       await makeExecutable(cliPath, osPlatform);
     }
 
+    // Print stackql version to action logs
+    const exeSuffix = osPlatform === 'win32' ? '.exe' : '';
+    const stackqlBin = path.join(cliPath, `stackql${exeSuffix}`);
+    core.info('stackql version:');
+    const versionOutput = execSync(`"${stackqlBin}" --version`, { encoding: 'utf-8' });
+    core.info(versionOutput.trim());
+
     // Check if wrapper is needed and if it's not Darwin
     const useWrapper = core.getInput('use_wrapper') === 'true';
     if (useWrapper && osPlatform !== 'darwin') {


### PR DESCRIPTION
…stry list

- index.js: run stackql --version after setup and log output to action logs (runs before wrapper install to use the original binary name)
- workflow: replace version check test with stackql exec REGISTRY LIST test that validates the JSON response is an array of {provider, version} objects

https://claude.ai/code/session_01Y8NseCm28GqE8nQ1Yvg5aa